### PR TITLE
fix(gha) correct GHA output to avoid empty values

### DIFF
--- a/github-actions-entrypoint.sh
+++ b/github-actions-entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh -le
 
-jv get --github-action-output
+jv get --github-action-output >> $GITHUB_OUTPUT

--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -111,7 +111,7 @@ func (c *GetCmd) Run() error {
 	}
 
 	if c.GithubActionOutput {
-		c.Log.Println(fmt.Sprintf("jenkins_version=%s >> $GITHUB_OUTPUT", v))
+		c.Log.Println(fmt.Sprintf("jenkins_version=%s", v))
 	} else {
 		c.Log.Println(v)
 	}

--- a/pkg/cmd/get_test.go
+++ b/pkg/cmd/get_test.go
@@ -24,13 +24,13 @@ func TestGet(t *testing.T) {
 
 	tests := []test{
 		{versionIdentifier: "latest", githubAction: false, expected: "2.276"},
-		{versionIdentifier: "latest", githubAction: true, expected: "jenkins_version=2.276 >> $GITHUB_OUTPUT"},
+		{versionIdentifier: "latest", githubAction: true, expected: "jenkins_version=2.276"},
 		{versionIdentifier: "weekly", githubAction: false, expected: "2.276"},
-		{versionIdentifier: "weekly", githubAction: true, expected: "jenkins_version=2.276 >> $GITHUB_OUTPUT"},
+		{versionIdentifier: "weekly", githubAction: true, expected: "jenkins_version=2.276"},
 		{versionIdentifier: "lts", githubAction: false, expected: "2.263.3"},
-		{versionIdentifier: "lts", githubAction: true, expected: "jenkins_version=2.263.3 >> $GITHUB_OUTPUT"},
+		{versionIdentifier: "lts", githubAction: true, expected: "jenkins_version=2.263.3"},
 		{versionIdentifier: "stable", githubAction: false, expected: "2.263.3"},
-		{versionIdentifier: "stable", githubAction: true, expected: "jenkins_version=2.263.3 >> $GITHUB_OUTPUT"},
+		{versionIdentifier: "stable", githubAction: true, expected: "jenkins_version=2.263.3"},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Fixup of #83

- The `jv` only prints the key / value when running on GHA
- The GHA entrypoints write the output of the CLI to the $ GITHUB_OUTPUT

A better and proper way would be to remove everything related to GHA in the go code and delegate. Consider this a hotfix first.