### PR TITLE
chore: pin GitHub actions with their SHA-1 instead of their version number

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,12 +9,9 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.18
-
       - name: Check out source code
         uses: actions/checkout@v3
-
       - name: Build
         run: make build
-
       - name: Test
         run: make test

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,4 +16,4 @@ jobs:
         with:
           go-version: 1.18
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,23 +1,18 @@
----
 on:
   release:
     types: [created]
-
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.16
-
       - name: Prepare
         id: prep
         run: |
@@ -28,16 +23,13 @@ jobs:
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
           echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
-
       - name: Local Branch
         run: |
           git switch -c ${{ steps.prep.outputs.version }}
-
       - name: Update action.yml
         run: |
           sed -i "s|image: .*|image: 'docker://${{ steps.prep.outputs.image }}:${{ steps.prep.outputs.version }}'|"  action.yml
           git diff
-
       - name: Update tag
         run: |
           RELEASE=$(gh api /repos/$GITHUB_REPOSITORY/releases/tags/${{ steps.prep.outputs.version }} | jq '.id')
@@ -59,36 +51,30 @@ jobs:
           GIT_COMMITTER_NAME: ${{ github.actor }}
           GIT_COMMITTER_EMAIL: ${{ github.actor }}@users.noreply.github.com
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: tibdex/github-app-token@v1
+      - uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1
         id: generate-token
         with:
           app_id: ${{ secrets.JENKINS_ADMIN_APP_ID }}
           private_key: ${{ secrets.JENKINS_ADMIN_APP_PRIVKEY }}
-
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4.2.0
+        uses: goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b # v4.2.0
         with:
           version: latest
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
+        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
+        uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7 # v2
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2
         with:
           username: ${{ secrets.DOCKERHUB_JENKINSCIINFRA_USERNAME }}
           password: ${{ secrets.DOCKERHUB_JENKINSCIINFRA_TOKEN }}
-
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4
         with:
           context: .
           push: true
@@ -105,4 +91,3 @@ jobs:
             org.label-schema.build-date=${{ steps.prep.outputs.created }}
           build-args: |
             JV_VERSION=${{ steps.prep.outputs.version }}
-...


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/3402