### PR TITLE
chore(golangci-lint) update setup for 0.5xy line 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,13 @@
 ---
 linters-settings:
   depguard:
-    list-type: blacklist
-    packages:
-      - github.com/alecthomas/assert
-      - github.com/magiconair/properties/assert
-    packages-with-error-message:
-      - github.com/alecthomas/assert: "use github.com/stretchr/testify/assert"
-      - github.com/magiconair/properties/assert: "use github.com/stretchr/testify/assert"
+    rules:
+      main:
+        deny:
+          - pkg: "github.com/alecthomas/assert"
+            desc: not allowed
+          - pkg: "github.com/magiconair/properties/assert"
+            desc: not allowed
   dupl:
     threshold: 100
   exhaustive:
@@ -67,7 +67,6 @@ linters:
   disable-all: true
   enable:
     - asciicheck
-    - deadcode
     - depguard
     - dogsled
     - errcheck
@@ -92,7 +91,6 @@ linters:
     - typecheck
     - unconvert
     - unused
-    - varcheck
     - whitespace
   # don't enable:
   # - bodyclose https://github.com/timakin/bodyclose/issues/30


### PR DESCRIPTION
This PR updates the configuration for `golangci-lint`:

- Removes dead linters, which removes the following warning message from the `golangci-lint` executions:

  ```console
  level=warning msg="[runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused."
  level=warning msg="[runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused."
  ```

- Fix depguard settings to remove the following look-a-like error messages in dependabot PRs:

  ```console
  Error: import '<pkg>' is not allowed from list 'Main' (depguard)
  ```