### PR TITLE
Revert "chore(deps): bump goreleaser/goreleaser-action from 4.3.0 to 4.4.0"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,7 @@ jobs:
           app_id: ${{ secrets.JENKINS_ADMIN_APP_ID }}
           private_key: ${{ secrets.JENKINS_ADMIN_APP_PRIVKEY }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@3fa32b8bb5620a2c1afe798654bbad59f9da4906 # v4.4.0
+        uses: goreleaser/goreleaser-action@336e29918d653399e599bfca99fadc1d7ffbc9f7 # v4.3.0
         with:
           version: latest
           args: release --rm-dist


### PR DESCRIPTION
Reverts jenkins-infra/jenkins-version#136

> Error: Can't use 'tar -xzf' extract archive file: /home/runner/work/_actions/_temp_9ec9b39a-f180-4354-8d13-7d7ce441fece/3d3dd83d-4462-425a-8d55-c03976b3ba8e.tar.gz. return code: 2.