### PR TITLE
chore(updatecli) track golang version

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -1,0 +1,36 @@
+name: updatecli
+on:
+  workflow_dispatch: null
+  schedule:
+    # Every monday
+    - cron: '* * * * 1'
+  push: null
+  pull_request: null
+jobs:
+  updatecli:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup updatecli
+        uses: updatecli/updatecli-action@v2
+      - name: Diff
+        continue-on-error: true
+        run: |
+          updatecli diff --config ./updatecli/updatecli.d --values ./updatecli/values.yaml
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ## This step allows to generate a short-lived token which is allowed to modify GitHub Workflow files (that the default GITHUB_TOKEN cannot)
+      ## Please make sure that the 2 secrets are defined (usually at organization level, with a per-repository access)
+      - uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.0
+        id: generate_token
+        if: github.ref == 'refs/heads/master'
+        with:
+          app_id: ${{ secrets.JENKINS_ADMIN_APP_ID }}
+          private_key: ${{ secrets.JENKINS_ADMIN_APP_PRIVKEY }}
+      - name: Apply
+        if: github.ref == 'refs/heads/master'
+        run: |
+          updatecli apply --config ./updatecli/updatecli.d --values ./updatecli/values.yaml
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/updatecli/updatecli.d/golang.yaml
+++ b/updatecli/updatecli.d/golang.yaml
@@ -1,0 +1,54 @@
+---
+name: Bump Golang version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestGoVersion:
+      name: Get latest Golang version
+      kind: golang
+
+targets:
+  updateGomod:
+    name: 'Update Golang version in go.mod to {{ source "latestGoVersion" }}'
+    kind: golang/gomod
+    sourceid: latestGoVersion
+    spec:
+      file: go.mod
+    scmid: default
+  updateGithubWorkflowGolang:
+    name: 'Update Golang version in GitHub "go" workflow to {{ source "latestGoVersion" }}'
+    sourceid: latestGoVersion
+    kind: yaml
+    spec:
+      file: .github/workflows/go.yml
+      key: $.jobs.build.steps[0].with.go-version
+    scmid: default
+  updateGithubWorkflowGolangCiLint:
+    name: 'Update Golang version in GitHub "golangcilint" workflow to {{ source "latestGoVersion" }}'
+    sourceid: latestGoVersion
+    kind: yaml
+    spec:
+      file: .github/workflows/golangci-lint.yml
+      key: $.jobs.golangci.steps[1].with.go-version
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump golang version to {{ source "latestGoVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - golang

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,0 +1,8 @@
+github:
+  user: "Jenkins Infra Bot (updatecli)"
+  email: "60776566+jenkins-infra-bot@users.noreply.github.com"
+  username: "jenkins-infra-bot"
+  token: "UPDATECLI_GITHUB_TOKEN"
+  branch: "main"
+  owner: "jenkins-infra"
+  repository: "jenkins-version"


### PR DESCRIPTION
This PR adds an updatecli manifest to track (and sync) Golang version in these 3 locations:

- `go.mod` file 
- GitHub workflow `go.yml`
- GitHub workflow `golangci-lint.yml`