### PR TITLE
chore: use new 'goreleaser in jenkins-infra' GitHub App

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,8 +54,8 @@ jobs:
       - uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
         id: generate-token
         with:
-          app_id: ${{ secrets.JENKINS_ADMIN_APP_ID }}
-          private_key: ${{ secrets.JENKINS_ADMIN_APP_PRIVKEY }}
+          app_id: ${{ secrets.GORELEASER_APP_ID }}
+          private_key: ${{ secrets.GORELEASER_APP_PRIVKEY }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:


### PR DESCRIPTION
This PR replaces the secrets used by the goreleaser GHA from "updatecli GHA in jenkins-infra" GitHub App credentials to the new "goreleaser in jenkins-infra" GitHub App credentials.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4141