### PR TITLE
chore: set goreleaser author email to Jenkins Infra team

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -68,7 +68,7 @@ brews:
       token: "{{ .Env.GITHUB_TOKEN }}"
     commit_author:
       name: jenkins-infra
-      email: gareth@bryncynfelin.co.uk
+      email: jenkins-infra-team@googlegroups.com
     directory: Formula
     description: "Determine a Jenkins Version"
     homepage: https://github.com/jenkins-infra/jenkins-version


### PR DESCRIPTION
Avoid taps publication by Gareth:

<img width="781" alt="image" src="https://github.com/jenkins-infra/jenkins-version/assets/91831478/980df5c8-6197-4be7-8c91-b38991bd03e1">
